### PR TITLE
NO-ISSUE: Remove agent-run from publish target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ build:
 push:
 	@echo "There is no Docker image push process since this container is provided by a third-party from official sources."
 
-publish: publish-service publish-service-policy publish-deployment-policy agent-run
+publish: publish-service publish-service-policy publish-deployment-policy
 
 # Pull, not push, Docker image since provided by third party
 publish-service:


### PR DESCRIPTION
This PR removes the agent-run target from the publish target in the Makefile. This change aligns with the pattern of keeping node registration separate from service publishing.